### PR TITLE
Connection type JSON struct

### DIFF
--- a/maxbws.json
+++ b/maxbws.json
@@ -2,7 +2,10 @@
  "cellular": [{
   "name": "IDEN",
   "version": "2G",
-  "ceiling": 64,
+  "ceiling": {
+   "downlink": 0.064,
+   "uplink": 0.064
+  },
   "latencyRange": "500-1500",
   "ref": {
    "url": "http://www.rfcafe.com/references/electrical/wireless-comm-specs-new.htm"
@@ -10,7 +13,10 @@
  }, {
   "name": "CDMA",
   "version": "2G",
-  "ceiling": 115,
+  "ceiling": {
+   "downlink": 0.115,
+   "uplink": 0.115
+  },
   "latencyRange": "500-1500",
   "ref": {
    "url": "http://www.rfcafe.com/references/electrical/wireless-comm-specs-new.htm"
@@ -18,7 +24,10 @@
  }, {
   "name": "1xRTT",
   "version": "2.5G",
-  "ceiling": 153,
+  "ceiling": {
+   "downlink": 0.153,
+   "uplink": 0.153
+  },
   "latencyRange": "500-1000",
   "ref": {
    "url": "http://en.wikipedia.org/wiki/CDMA2000#1X"
@@ -26,7 +35,10 @@
  }, {
   "name": "GPRS",
   "version": "2.5G",
-  "ceiling": 237,
+  "ceiling": {
+   "downlink": 0.237,
+   "uplink": 0.237
+  },
   "latencyRange": "500-1000",
   "ref": {
    "url": "http://en.wikipedia.org/wiki/General_Packet_Radio_Service"
@@ -34,7 +46,10 @@
  }, {
   "name": "EDGE",
   "version": "2.75G",
-  "ceiling": 384,
+  "ceiling": {
+   "downlink": 0.384,
+   "uplink": 0.384
+  },
   "latencyRange": "500-600",
   "ref": {
    "url": "http://www.umtsworld.com/technology/edge.htm"
@@ -42,7 +57,10 @@
  }, {
   "name": "UMTS",
   "version": "3G",
-  "ceiling": 2000,
+  "ceiling": {
+   "downlink": 2.0,
+   "uplink": 2.0
+  },
   "latencyRange": "150-450",
   "ref": {
    "url": "http://www.radio-electronics.com/info/cellulartelecomms/3g-hspa/umts-high-speed-packet-access-tutorial.php"
@@ -50,7 +68,10 @@
  }, {
   "name": "EVDO Rev 0",
   "version": "3.5G",
-  "ceiling": 2460,
+  "ceiling": {
+   "downlink": 2.46,
+   "uplink": 2.46
+  },
   "latencyRange": "150-350",
   "ref": {
    "url": "http://en.wikipedia.org/wiki/Comparison_of_wireless_data_standards#Peak_bit_rate_and_throughput"
@@ -58,7 +79,10 @@
  }, {
   "name": "EVDO Rev A",
   "version": "3.5G",
-  "ceiling": 3100,
+  "ceiling": {
+   "downlink": 3.1,
+   "uplink": 3.1
+  },
   "latencyRange": "100-250",
   "ref": {
    "url": "http://en.wikipedia.org/wiki/Evolution-Data_Optimized#TIA-856_Rev._A"
@@ -66,7 +90,10 @@
  }, {
   "name": "HSPA",
   "version": "3.5G",
-  "ceiling": 3600,
+  "ceiling": {
+   "downlink": 3.6,
+   "uplink": 3.6
+  },
   "latencyRange": "100-250",
   "ref": {
    "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247"
@@ -74,7 +101,10 @@
  }, {
   "name": "EVDO Rev B",
   "version": "3.75G",
-  "ceiling": 14700,
+  "ceiling": {
+   "downlink": 14.7,
+   "uplink": 14.7
+  },
   "latencyRange": "70-150",
   "ref": {
    "url": "http://en.wikipedia.org/wiki/Evolution-Data_Optimized#TIA-856_Rev._B"
@@ -82,7 +112,10 @@
  }, {
   "name": "HSDPA",
   "version": "3.75G",
-  "ceiling": 14400,
+  "ceiling": {
+   "downlink": 14.4,
+   "uplink": 14.4
+  },
   "latencyRange": "70-150",
   "ref": {
    "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247"
@@ -90,7 +123,10 @@
  }, {
   "name": "HSUPA",
   "version": "3.75G",
-  "ceiling": 14400,
+  "ceiling": {
+   "downlink": 14.4,
+   "uplink": 14.4
+  },
   "latencyRange": "70-150",
   "ref": {
    "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247"
@@ -98,7 +134,10 @@
  }, {
   "name": "EHRPD",
   "version": "3.9G",
-  "ceiling": 21000,
+  "ceiling": {
+   "downlink": 21.0,
+   "uplink": 21.0
+  },
   "latencyRange": "50-150",
   "ref": {
    "url": "http://www.cdg.org/news/events/cdmaseminar/09_TechForum_Sept/presentations/5-Spirent-ehrpd_9_handouts.pdf",
@@ -107,7 +146,10 @@
  }, {
   "name": "HSPAP",
   "version": "3.9G",
-  "ceiling": 42000,
+  "ceiling": {
+   "downlink": 42.0,
+   "uplink": 42.0
+  },
   "latencyRange": "50-100",
   "ref": {
    "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=248"
@@ -115,7 +157,10 @@
  }, {
   "name": "LTE",
   "version": "4G",
-  "ceiling": 100000,
+  "ceiling": {
+   "downlink": 100.0,
+   "uplink": 100.0
+  },
   "latencyRange": "20-70",
   "ref": {
    "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=249"
@@ -123,7 +168,10 @@
  }, {
   "name": "LTE Advanced",
   "version": "4G",
-  "ceiling": 100000,
+  "ceiling": {
+   "downlink": 100.0,
+   "uplink": 100.0
+  },
   "latencyRange": "20-50",
   "ref": {
    "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=249"

--- a/maxbws.json
+++ b/maxbws.json
@@ -1,154 +1,133 @@
 {
  "cellular": [{
-  // Ref: http://www.rfcafe.com/references/electrical/wireless-comm-specs-new.htm
   "name": "IDEN",
   "version": "2G",
-  "type": {
-   "android": "NETWORK_TYPE_IDEN",
-   "ios": ""
-  },
   "ceiling": 64,
-  "latencyRange": "500-1500"
+  "latencyRange": "500-1500",
+  "ref": {
+   "url": "http://www.rfcafe.com/references/electrical/wireless-comm-specs-new.htm"
+  }
  }, {
-  // Ref: http://www.rfcafe.com/references/electrical/wireless-comm-specs-new.htm
   "name": "CDMA",
   "version": "2G",
-  "type": {
-   "android": "NETWORK_TYPE_CDMA",
-   "ios": ""
-  },
   "ceiling": 115,
-  "latencyRange": "500-1500"
+  "latencyRange": "500-1500",
+  "ref": {
+   "url": "http://www.rfcafe.com/references/electrical/wireless-comm-specs-new.htm"
+  }
  }, {
-  // Ref: http://en.wikipedia.org/wiki/CDMA2000#1X
   "name": "1xRTT",
   "version": "2.5G",
-  "type": {
-   "android": "NETWORK_TYPE_1xRTT",
-   "ios": "CTRadioAccessTechnologyCDMA1x"
-  },
   "ceiling": 153,
-  "latencyRange": "500-1000"
+  "latencyRange": "500-1000",
+  "ref": {
+   "url": "http://en.wikipedia.org/wiki/CDMA2000#1X"
+  }
  }, {
-  // Ref: http://en.wikipedia.org/wiki/General_Packet_Radio_Service
   "name": "GPRS",
   "version": "2.5G",
-  "type": {
-   "android": "NETWORK_TYPE_GPRS",
-   "ios": "CTRadioAccessTechnologyGPRS"
-  },
   "ceiling": 237,
-  "latencyRange": "500-1000"
+  "latencyRange": "500-1000",
+  "ref": {
+   "url": "http://en.wikipedia.org/wiki/General_Packet_Radio_Service"
+  }
  }, {
-  // Ref: http://www.umtsworld.com/technology/edge.htm
   "name": "EDGE",
   "version": "2.75G",
-  "type": {
-   "android": "NETWORK_TYPE_EDGE",
-   "ios": "CTRadioAccessTechnologyEdge"
-  },
   "ceiling": 384,
-  "latencyRange": "500-600"
+  "latencyRange": "500-600",
+  "ref": {
+   "url": "http://www.umtsworld.com/technology/edge.htm"
+  }
  }, {
-  // Ref: http://www.radio-electronics.com/info/cellulartelecomms/3g-hspa/umts-high-speed-packet-access-tutorial.php
   "name": "UMTS",
   "version": "3G",
-  "type": {
-   "android": "NETWORK_TYPE_UMTS",
-   "ios": "CTRadioAccessTechnologyWCDMA"
-  },
   "ceiling": 2000,
-  "latencyRange": "150-450"
+  "latencyRange": "150-450",
+  "ref": {
+   "url": "http://www.radio-electronics.com/info/cellulartelecomms/3g-hspa/umts-high-speed-packet-access-tutorial.php"
+  }
  }, {
-  // Ref: http://en.wikipedia.org/wiki/Comparison_of_wireless_data_standards#Peak_bit_rate_and_throughput
   "name": "EVDO Rev 0",
   "version": "3.5G",
-  "type": {
-   "android": "NETWORK_TYPE_EVDO_0",
-   "ios": "CTRadioAccessTechnologyCDMAEVDORev0"
-  },
   "ceiling": 2460,
-  "latencyRange": "150-350"
+  "latencyRange": "150-350",
+  "ref": {
+   "url": "http://en.wikipedia.org/wiki/Comparison_of_wireless_data_standards#Peak_bit_rate_and_throughput"
+  }
  }, {
-  // Ref: http://en.wikipedia.org/wiki/Evolution-Data_Optimized#TIA-856_Rev._A
   "name": "EVDO Rev A",
   "version": "3.5G",
-  "type": {
-   "android": "NETWORK_TYPE_EVDO_A",
-   "ios": "CTRadioAccessTechnologyCDMAEVDORevA"
-  },
   "ceiling": 3100,
-  "latencyRange": "100-250"
+  "latencyRange": "100-250",
+  "ref": {
+   "url": "http://en.wikipedia.org/wiki/Evolution-Data_Optimized#TIA-856_Rev._A"
+  }
  }, {
-  // Ref: http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247
   "name": "HSPA",
   "version": "3.5G",
-  "type": {
-   "android": "NETWORK_TYPE_HSPA",
-   "ios": ""
-  },
   "ceiling": 3600,
-  "latencyRange": "100-250"
+  "latencyRange": "100-250",
+  "ref": {
+   "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247"
+  }
  }, {
-  // Ref: http://en.wikipedia.org/wiki/Evolution-Data_Optimized#TIA-856_Rev._B
   "name": "EVDO Rev B",
   "version": "3.75G",
-  "type": {
-   "android": "NETWORK_TYPE_EVDO_B",
-   "ios": "CTRadioAccessTechnologyCDMAEVDORevB"
-  },
   "ceiling": 14700,
-  "latencyRange": "70-150"
+  "latencyRange": "70-150",
+  "ref": {
+   "url": "http://en.wikipedia.org/wiki/Evolution-Data_Optimized#TIA-856_Rev._B"
+  }
  }, {
-  // Ref: http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247
   "name": "HSDPA",
   "version": "3.75G",
-  "type": {
-   "android": "NETWORK_TYPE_HSDPA",
-   "ios": "CTRadioAccessTechnologyHSDPA"
-  },
   "ceiling": 14400,
-  "latencyRange": "70-150"
+  "latencyRange": "70-150",
+  "ref": {
+   "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247"
+  }
  }, {
-  // Ref: http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247
   "name": "HSUPA",
   "version": "3.75G",
-  "type": {
-   "android": "NETWORK_TYPE_HSUPA",
-   "ios": "CTRadioAccessTechnologyHSUPA"
-  },
   "ceiling": 14400,
-  "latencyRange": "70-150"
+  "latencyRange": "70-150",
+  "ref": {
+   "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247"
+  }
  }, {
-  // Ref: http://www.cdg.org/news/events/cdmaseminar/09_TechForum_Sept/presentations/5-Spirent-ehrpd_9_handouts.pdf
   "name": "EHRPD",
   "version": "3.9G",
-  "type": {
-   "android": "NETWORK_TYPE_EHRPD",
-   "ios": "CTRadioAccessTechnologyeHRPD"
-  },
   "ceiling": 21000,
-  "latencyRange": "50-150"
+  "latencyRange": "50-150",
+  "ref": {
+   "url": "http://www.cdg.org/news/events/cdmaseminar/09_TechForum_Sept/presentations/5-Spirent-ehrpd_9_handouts.pdf",
+   "note": "eHRPD is a method of interworking multiple access networks (eHRPD, E-UTRAN), as such it's a mix of 3.75G-4G technologies, and there isn't a single ceiling value. As a result, 21000kbps is an in-between value."
+  }
  }, {
-  // Ref: http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=248
   "name": "HSPAP",
   "version": "3.9G",
-  "type": {
-   "android": "NETWORK_TYPE_HSPAP",
-   "ios": ""
-  },
   "ceiling": 42000,
-  "latencyRange": "50-100"
+  "latencyRange": "50-100",
+  "ref": {
+   "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=248"
+  }
  }, {
-  // Ref: http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=249
   "name": "LTE",
   "version": "4G",
-  "type": {
-   "android": "NETWORK_TYPE_LTE",
-   "ios": "CTRadioAccessTechnologyLTE"
-  },
   "ceiling": 100000,
-  "latencyRange": "20-70"
+  "latencyRange": "20-70",
+  "ref": {
+   "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=249"
+  }
+ }, {
+  "name": "LTE Advanced",
+  "version": "4G",
+  "ceiling": 100000,
+  "latencyRange": "20-50",
+  "ref": {
+   "url": "http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=249"
+  }
  }],
 
  "bluetooth": [{

--- a/maxbws.json
+++ b/maxbws.json
@@ -1,14 +1,166 @@
 {
-  "cellular": [
-  	{"version": "", "maxmegabytes": }
-  ],
-  "bluetooth": [
-  	{"version": "", "maxmegabytes": }
-  ],
-  "ethernet": [
-  	{"version": "", "maxmegabytes": }
-  ],
-  "wifi": [
-  	{"version": "", "maxmegabytes": }
-  ]
+ "cellular": [{
+  // Ref: http://www.rfcafe.com/references/electrical/wireless-comm-specs-new.htm
+  "name": "IDEN",
+  "version": "2G",
+  "type": {
+   "android": "NETWORK_TYPE_IDEN",
+   "ios": ""
+  },
+  "ceiling": 64,
+  "latencyRange": "500-1500"
+ }, {
+  // Ref: http://www.rfcafe.com/references/electrical/wireless-comm-specs-new.htm
+  "name": "CDMA",
+  "version": "2G",
+  "type": {
+   "android": "NETWORK_TYPE_CDMA",
+   "ios": ""
+  },
+  "ceiling": 115,
+  "latencyRange": "500-1500"
+ }, {
+  // Ref: http://en.wikipedia.org/wiki/CDMA2000#1X
+  "name": "1xRTT",
+  "version": "2.5G",
+  "type": {
+   "android": "NETWORK_TYPE_1xRTT",
+   "ios": "CTRadioAccessTechnologyCDMA1x"
+  },
+  "ceiling": 153,
+  "latencyRange": "500-1000"
+ }, {
+  // Ref: http://en.wikipedia.org/wiki/General_Packet_Radio_Service
+  "name": "GPRS",
+  "version": "2.5G",
+  "type": {
+   "android": "NETWORK_TYPE_GPRS",
+   "ios": "CTRadioAccessTechnologyGPRS"
+  },
+  "ceiling": 237,
+  "latencyRange": "500-1000"
+ }, {
+  // Ref: http://www.umtsworld.com/technology/edge.htm
+  "name": "EDGE",
+  "version": "2.75G",
+  "type": {
+   "android": "NETWORK_TYPE_EDGE",
+   "ios": "CTRadioAccessTechnologyEdge"
+  },
+  "ceiling": 384,
+  "latencyRange": "500-600"
+ }, {
+  // Ref: http://www.radio-electronics.com/info/cellulartelecomms/3g-hspa/umts-high-speed-packet-access-tutorial.php
+  "name": "UMTS",
+  "version": "3G",
+  "type": {
+   "android": "NETWORK_TYPE_UMTS",
+   "ios": "CTRadioAccessTechnologyWCDMA"
+  },
+  "ceiling": 2000,
+  "latencyRange": "150-450"
+ }, {
+  // Ref: http://en.wikipedia.org/wiki/Comparison_of_wireless_data_standards#Peak_bit_rate_and_throughput
+  "name": "EVDO Rev 0",
+  "version": "3.5G",
+  "type": {
+   "android": "NETWORK_TYPE_EVDO_0",
+   "ios": "CTRadioAccessTechnologyCDMAEVDORev0"
+  },
+  "ceiling": 2460,
+  "latencyRange": "150-350"
+ }, {
+  // Ref: http://en.wikipedia.org/wiki/Evolution-Data_Optimized#TIA-856_Rev._A
+  "name": "EVDO Rev A",
+  "version": "3.5G",
+  "type": {
+   "android": "NETWORK_TYPE_EVDO_A",
+   "ios": "CTRadioAccessTechnologyCDMAEVDORevA"
+  },
+  "ceiling": 3100,
+  "latencyRange": "100-250"
+ }, {
+  // Ref: http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247
+  "name": "HSPA",
+  "version": "3.5G",
+  "type": {
+   "android": "NETWORK_TYPE_HSPA",
+   "ios": ""
+  },
+  "ceiling": 3600,
+  "latencyRange": "100-250"
+ }, {
+  // Ref: http://en.wikipedia.org/wiki/Evolution-Data_Optimized#TIA-856_Rev._B
+  "name": "EVDO Rev B",
+  "version": "3.75G",
+  "type": {
+   "android": "NETWORK_TYPE_EVDO_B",
+   "ios": "CTRadioAccessTechnologyCDMAEVDORevB"
+  },
+  "ceiling": 14700,
+  "latencyRange": "70-150"
+ }, {
+  // Ref: http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247
+  "name": "HSDPA",
+  "version": "3.75G",
+  "type": {
+   "android": "NETWORK_TYPE_HSDPA",
+   "ios": "CTRadioAccessTechnologyHSDPA"
+  },
+  "ceiling": 14400,
+  "latencyRange": "70-150"
+ }, {
+  // Ref: http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=247
+  "name": "HSUPA",
+  "version": "3.75G",
+  "type": {
+   "android": "NETWORK_TYPE_HSUPA",
+   "ios": "CTRadioAccessTechnologyHSUPA"
+  },
+  "ceiling": 14400,
+  "latencyRange": "70-150"
+ }, {
+  // Ref: http://www.cdg.org/news/events/cdmaseminar/09_TechForum_Sept/presentations/5-Spirent-ehrpd_9_handouts.pdf
+  "name": "EHRPD",
+  "version": "3.9G",
+  "type": {
+   "android": "NETWORK_TYPE_EHRPD",
+   "ios": "CTRadioAccessTechnologyeHRPD"
+  },
+  "ceiling": 21000,
+  "latencyRange": "50-150"
+ }, {
+  // Ref: http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=248
+  "name": "HSPAP",
+  "version": "3.9G",
+  "type": {
+   "android": "NETWORK_TYPE_HSPAP",
+   "ios": ""
+  },
+  "ceiling": 42000,
+  "latencyRange": "50-100"
+ }, {
+  // Ref: http://www.4gamericas.org/index.cfm?fuseaction=page&sectionid=249
+  "name": "LTE",
+  "version": "4G",
+  "type": {
+   "android": "NETWORK_TYPE_LTE",
+   "ios": "CTRadioAccessTechnologyLTE"
+  },
+  "ceiling": 100000,
+  "latencyRange": "20-70"
+ }],
+
+ "bluetooth": [{
+  "version": "",
+  "maxmegabytes":
+ }],
+ "ethernet": [{
+  "version": "",
+  "maxmegabytes":
+ }],
+ "wifi": [{
+  "version": "",
+  "maxmegabytes":
+ }]
 }


### PR DESCRIPTION
First run at the (cellular) connection info JSON struct based on data from: https://docs.google.com/spreadsheets/d/16csKPy0dC2Hs6OHbLdWf0qlDiiRreqPtsMEE8vebRYo/edit
- `ceiling` value is in kbps (kilobits per second). I initially used MiB/s, but there is some precision loss when I do that, and I wanted to keep it faithful to the numbers that are usually used in the standard specs. That said, when we report them in the UA, I think we should still convert these to MBps or MiB/s. 
- `type` could arguably live in a comment, but I'm erring on the side of too much information, and it might as well be structured data? It's a non-trivial exercise to map some of the different connection types across different platforms to a consistent name. 
- `latencyRange` is in ms. Once again, erring on the side of too much info. 

The reason I'm erring on the side of "too much" is because finding a good source of structured data on this stuff is really darn hard, and perhaps this could be it -- pull in this JSON and you have all you need. On that note, I'm also entertaining making ceiling an object with two values: uplink, downlink.

Am I crazy? Feel free to tell me that I am. :) 
