### PR TITLE
downlinkMax can be determined by network weather

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,10 +180,10 @@ The <dfn>`downlinkMax`</dfn> attribute represents the <a>maximum downlink speed<
 
 <section>
 
-##Underlying connection technology
+## Underlying connection technology
 The <dfn>underlying connection technology</dfn> represents the generation and/or version of the network connection being used by the device. For example, "HSPA" (3.5G) for cellular, or "802.11g" for Wi-Fi. This differs from the <a>connection type</a> exposed by the API, in that it is more fine grained.
 
-Each <a>underlying connection technology</a> has an associated <dfn>maximum downlink speed</dfn>, which is the standardized, or generally accepted, maximum download data rate in <a>megabits</a> per second. The relationship between an <a>underlying connection technology</a> and its <a>maximum downlink speed</a> is captured in the <a>table of maximum downlink speeds</a>.
+Each <a>underlying connection technology</a> has an associated <dfn>maximum downlink speed</dfn>, which is the maximum download data rate of the current network interface in <a>megabits</a> per second. The relationship between an <a>underlying connection technology</a> and its <a>maximum downlink speed</a> is determined by the properties of the current network interface (e.g signal strength, modulation algorithm, and other relevant "network weather" variables), or where such interface information is not available, is determined by the standardized, or generally accepted, maximum download data rate captured in the <a>table of maximum downlink speeds</a>.
 
 <div class="note">
 The <a>underlying connection technology</a> is not directly exposed to script. Instead, the <a>maximum downlink speed</a> is exposed via the <a href="#widl-NetworkInformation-downlinkMax">`downlinkMax`</a> attribute.
@@ -214,7 +214,7 @@ If the <a>underlying connection technology</a> changes (in either connection typ
 1. Let <var>max-value</var> be `+Infinity`.
 1. If <var>new-type</var> is "none", set <var>max-value</var> to `0`.
 1. Otherwise, if <var>new-type</var> is not "unknown":
-    1. Set <var>max-value</var> to the <a>maximum downlink speed</a> of the <a>underlying connection technology</a> from the <a>table of maximum downlink speeds</a>.
+    1. Set <var>max-value</var> to the <a>maximum downlink speed</a> of the <a>underlying connection technology</a> as determined by the properties of the current network interface, or where such interface information is not available, using the <a>table of maximum downlink speeds</a>.
 1. If <var>max-value</var> is not equal to the value of `connection.downlinkMax` or if <var>new-type</var> is not equal to the value of `connection.type`:
     1. Using the <a>networking task source</a>, queue a <a>task</a> to perform the following:
         1. Set `connection.downlinkMax` to <var>max-value</var>.
@@ -275,7 +275,7 @@ If the <a>underlying connection technology</a> changes (in either connection typ
       head = document.querySelector("#max-downlink-table > thead"),
       headsize = head.rows[0].children.length,
       trs = "";
-    //for each entry in the JSON 
+    //for each entry in the JSON
     for (var connection in data) {
       var connectionTypes = data[connection];
       trs += "<tr>"


### PR DESCRIPTION
Where available, use the interface information to provide more accurate
estimate of downlinkMax - e.g. based on signal strength and similar
variables. If such information is not available, then fallback to the
standardized maximum dowlink values.

Closes #17
