### PR TITLE
Increased 802.11ac link speed

### DIFF
--- a/downlink.json
+++ b/downlink.json
@@ -359,7 +359,7 @@
     },
     "latencyRange": "0+",
     "ref": {
-      "url": "http://en.wikipedia.org/wiki/IEEE_802.11#802.11ac"
+      "url": "http://www.cisco.com/c/en/us/solutions/collateral/enterprise-networks/802-11ac-solution/q-and-a-c67-734152.html"
     }
   }, {
     "name": "ad",

--- a/downlink.json
+++ b/downlink.json
@@ -354,8 +354,8 @@
     "name": "ac",
     "version": "802.11ac",
     "max": {
-      "downlink": 1300.0,
-      "uplink": 1300.0
+      "downlink": 6900.0,
+      "uplink": 6900.0
     },
     "latencyRange": "0+",
     "ref": {

--- a/downlink.json
+++ b/downlink.json
@@ -354,8 +354,8 @@
     "name": "ac",
     "version": "802.11ac",
     "max": {
-      "downlink": 6900.0,
-      "uplink": 6900.0
+      "downlink": 6933.3,
+      "uplink": 6933.3
     },
     "latencyRange": "0+",
     "ref": {


### PR DESCRIPTION
The maximum 802.11ac speed listed in this table is incorrect. The maximum speed of an 802.11ac connection is 6900 Mbps (8T8R on both ends over a 160MHz channel in 5GHz spectrum).

I'd also be okay with capping it at ~3400 Mbps (4T4R @ 160MHz) until 802.11ac hardware surpasses that point.
