### PR TITLE
editorial: clean up markdown, xrefs, sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ var respecConfig = {
   shortName: "netinfo-api",
   format: "markdown",
   subtitle: "Living Document",
-  edDraftURI: "https://wicg.github.io/netinfo/",
+  github: "https://github.com/WICG/netinfo/",
   editors: [
     {
       name: "Ilya Grigorik",
@@ -76,26 +76,7 @@ var respecConfig = {
   ],
   wg: "Web Incubator Community Group",
   wgURI: "https://wicg.io",
-  wgPublicList: "public-wicg",
-  noLegacyStyle: true,
   otherLinks: [
-    {
-      key: "Repository",
-      data: [
-        {
-          value: "We are on Github.",
-          href: "https://github.com/WICG/netinfo",
-        },
-        {
-          value: "File a bug.",
-          href: "https://github.com/WICG/netinfo/issues",
-        },
-        {
-          value: "Commit history.",
-          href: "https://github.com/WICG/netinfo/commits/gh-pages",
-        },
-      ],
-    },
     {
       key: "Implementations",
       data: [

--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<head>
 <meta charset='utf-8'>
 <title>Network Information API</title>
 <script class='remove' src='//www.w3.org/Tools/respec/respec-w3c-common'></script>
@@ -110,200 +109,233 @@ var respecConfig = {
   preProcess: [loadTableData],
 };
 </script>
-</head>
-<body>
 
 <section id='abstract'>
-The <cite>Network Information API</cite> enables web applications to access information about the network connection in use by the device.
+  The <cite>Network Information API</cite> enables web applications to access information about the network connection in use by the device.
 </section>
 
-<section id='sotd'>
-</section>
+<section id='sotd'></section>
 
-<section id="use-cases">
 ## Use cases and requirements
-This document attempts to address the [requirements](https://github.com/w3c-webmob/netinfo/blob/master/README.md) from the <cite>[Review of Apps that Use Network Information](https://github.com/w3c-webmob/netinfo)</cite> document published by the <a href="http://www.w3.org/Mobile/IG/">Web and Mobile Interest Group</a>. Those are:
+
+This document attempts to address the <a data-cite="netinfo-usecases#requirements">requirements</a> from the <a data-cite="netinfo-usecases">Review of Apps that Use Network Information</a>. Those are:
 
  * Provide access to the <a>connection type</a> the system is using to communicate with the network (e.g., cellular, bluetooth, ethernet, wifi, other, or none). This information needs to be available either immediately on page load or as close as possible to it.
  * Provide a means for scripts to be notified if the <a>connection type</a> changes. This is to allow developers to make dynamic changes to the DOM and/or inform the user that the network <a>connection type</a> has changed (and that it could impact them in some way).
-</section>
 
 <section class="informative">
-## Examples of usage
-For examples of the kinds of applications one can build with this API, see the <cite>[Review of Apps that Use Network Information](https://github.com/w3c-webmob/netinfo)</cite>.
+  ## Examples of usage
+  For examples of the kinds of applications one can build with this API, see the <cite>[Review of Apps that Use Network Information](https://github.com/w3c-webmob/netinfo)</cite>.
 
-<pre class="example">
-// Get the connection type.
-var type = navigator.connection.type;
+  <pre class="example js">
+    // Get the connection type.
+    var type = navigator.connection.type;
 
-// Get an upper bound on the downlink speed of the first network hop
-var max = navigator.connection.downlinkMax;
+    // Get an upper bound on the downlink speed of the first network hop
+    var max = navigator.connection.downlinkMax;
 
-function changeHandler(e) {
-  // Handle change to connection here.
-}
+    function changeHandler(e) {
+      // Handle change to connection here.
+    }
 
-// Register for event changes.
-navigator.connection.onchange = changeHandler;
+    // Register for event changes.
+    navigator.connection.onchange = changeHandler;
 
-// Alternatively.
-navigator.connection.addEventListener('change', changeHandler);
-</pre>
+    // Alternatively.
+    navigator.connection.addEventListener('change', changeHandler);
+  </pre>
 </section>
 
-<section>
+
 ## Definitions
 
 For clarity, a <dfn>megabit</dfn> is 1,000,000 bits, and <dfn data-lt="Mbit/s">megabits per second</dfn> is equivalent to transferring:
 
-* 1,000,000 bits per second
-* 1,000 kilobits per second
-* 125,000 bytes per second
-* 125 kilobytes per second
-* and so on...
+  * 1,000,000 bits per second
+  * 1,000 kilobits per second
+  * 125,000 bytes per second
+  * 125 kilobytes per second
+  * and so on...
 
-</section>
 
-<section>
 ## Connection types
 
-  <section data-dfn-for="ConnectionType" data-link-for="ConnectionType">
-  ### Underlying connection technology
-  This section defines the <dfn data-lt="connection type">connection types</dfn>:
+### Underlying connection technology
 
-  <dl>
-    <dt><dfn>bluetooth</dfn></dt>
-    <dd>The user agent is using a Bluetooth connection as the <a>underlying connection technology</a>.</dd>
-    <dt><dfn>cellular</dfn></dt>
-    <dd>The user agent is using a cellular connection as the <a>underlying connection technology</a> (e.g., EDGE, HSPA, LTE, etc.).</dd>
-    <dt><dfn>ethernet</dfn></dt>
-    <dd>The user agent is using an Ethernet connection as the <a>underlying connection technology</a>.</dd>
-    <dt><dfn>none</dfn></dt>
-    <dd>The user agent will not contact the network when the user follows links or when a script requests a remote page (or knows that such an attempt would fail) - i.e., equivalent to `navigator.onLine === false` in HTML.</dd>
-    <dt><dfn>wifi</dfn></dt>
-    <dd>The user agent is using a Wi-Fi connection as the <a>underlying connection technology</a>.</dd>
-    <dt><dfn>wimax</dfn></dt>
-    <dd>The user agent is using a WiMAX connection as the <a>underlying connection technology</a>.</dd>
-    <dt><dfn>other</dfn></dt>
-    <dd>The user agent is using a connection type that is not one of enumerated connection types as the <a>underlying connection technology</a>.</dd>
-    <dt><dfn>mixed</dfn></dt>
-    <dd>The user agent is using multiple connection types as the <a>underlying connection technology</a>.</dd>
-    <dt><dfn>unknown</dfn></dt>
-    <dd>The user agent has established a network connection, but is unable to determine what is the <a>underlying connection technology</a>.</dd>
-  </dl>
-  </section>
+This section defines the <dfn data-lt="connection type">connection types</dfn> and the <a>underlying connection technology</a> that the <a>user agent</a> is using (if any):
 
-  <section>
-  ### Effective connection types
-  This section defines the <dfn data-lt="effective connection type">effective connection types</dfn> (ECT):
+<dl data-dfn-for="ConnectionType">
+  <dt><dfn>bluetooth</dfn></dt>
+  <dd>A Bluetooth connection.</dd>
+  <dt><dfn>cellular</dfn></dt>
+  <dd>A cellular connection (e.g., EDGE, HSPA, LTE, etc.).</dd>
+  <dt><dfn>ethernet</dfn></dt>
+  <dd>An Ethernet connection.</dd>
+  <dt><dfn>none</dfn></dt>
+  <dd>No network connection. The user agent will not contact the network when the user follows links or when a script requests a remote page (or knows that such an attempt would fail) - i.e., equivalent to `navigator.onLine === false` in HTML.</dd>
+  <dt><dfn>mixed</dfn></dt>
+  <dd>The user agent is using multiple connection types.</dd>
+  <dt><dfn>other</dfn></dt>
+  <dd>The connection type that is known, but not one of enumerated connection types.</dd>
+  <dt><dfn>unknown</dfn></dt>
+  <dd>The user agent has established a network connection, but is unable, or unwilling, to determine the <a>underlying connection technology</a>.</dd>
+  <dt><dfn>wifi</dfn></dt>
+  <dd>A Wi-Fi connection.</dd>
+  <dt><dfn>wimax</dfn></dt>
+  <dd>A WiMAX connection.</dd>
+</dl>
 
-  <table id="effective-connection-type-table" data-dfn-for="EffectiveConnectionType">
-    <caption><dfn>Table of effective connection types</dfn></caption>
-    <thead>
-      <tr>
-        <th>ECT</th>
-        <th>Minimum RTT (ms)</th>
-        <th>Maximum downlink (Kbps)</th>
-        <th>Explanation</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><dfn>slow-2g</dfn></td>
-        <td>1900</td>
-        <td>50</td>
-        <td>The network is suited for small transfers only such as text-only pages.</td>
-      </tr>
-      <tr>
-        <td><dfn>2g</dfn></td>
-        <td>1300</td>
-        <td>70</td>
-        <td>The network is suited for transfers of small images.</td>
-      </tr>
-      <tr>
-        <td><dfn>3g</dfn></td>
-        <td>200</td>
-        <td>700</td>
-        <td>The network is suited for transfers of large assets such as high resolution images, audio, and SD video.</td>
-      </tr>
-      <tr>
-        <td><dfn>4g</dfn></td>
-        <td>0</td>
-        <td>∞</td>
-        <td>The network is suited for HD video, real-time video, etc.</td>
-      </tr>
-    </tbody>
-  </table>
-  <p>The above roundtrip and bandwidth values are based on real user measurement observations:</p>
-  <ul>
-    <li>`slow-2g` is the 66.6th percentile of 2G observations</li>
-    <li>`2g` is the 50th percentile of 2G observations</li>
-    <li>`3g` is the 50th percentile of 3G observations</li>
-  </ul>
-  <p>The absolute values provided above are based on real user measurement on Chrome on Android, as captured in April 2017. The user agent MAY update these values in the future to reflect changes in the measurement data.</p>
-  </section>
-</section>
+The <a>connection types</a> are represented in this API by the <a>ConnectionType</a> enum.
 
-
-<section data-dfn-for="NavigatorNetworkInformation" data-link-for="NavigatorNetworkInformation">
-## Extensions to the `Navigator` interface
-The <dfn>`NavigatorNetworkInformation`</dfn> interface exposes access to <a>`NetworkInformation`</a> interface.
-
-<pre class=idl>
-[NoInterfaceObject, Exposed=(Window,Worker)]
-interface NavigatorNetworkInformation {
-   readonly attribute NetworkInformation connection;
-};
-
-Navigator implements NavigatorNetworkInformation;
-WorkerNavigator implements NavigatorNetworkInformation;
-</pre>
-
-### The `connection` attribute
-The <dfn id="widl-Navigator-connection">`connection`</dfn> attribute, when getting, returns an object that implements the <a>`NetworkInformation`</a> interface.
-</section>
-
-<section data-dfn-for="NetworkInformation" data-link-for="NetworkInformation">
-## The `NetworkInformation` interface
-The <dfn>`NetworkInformation`</dfn> interface provides a means to access information about the network connection the user agent is currently using.
+### <dfn>ConnectionType</dfn> enum
 
 <pre class="idl">
-[Exposed=(Window,Worker)]
-interface NetworkInformation : EventTarget{
-  readonly attribute ConnectionType type;
-  readonly attribute EffectiveConnectionType effectiveType;
-  readonly attribute Megabit downlinkMax;
-  readonly attribute Megabit downlink;
-  readonly attribute Millisecond rtt;
-  attribute EventHandler onchange;
-};
+  enum ConnectionType {
+    "bluetooth",
+    "cellular",
+    "ethernet",
+    "mixed",
+    "none",
+    "other",
+    "unknown",
+    "wifi",
+    "wimax"
+  };
+</pre>
 
-typedef unrestricted double Megabit;
-typedef unsigned long long Millisecond;
+### Effective connection types
+
+This section defines the <dfn data-lt="effective connection type">effective connection types</dfn> (ECT):
+
+<table id="effective-connection-type-table" data-dfn-for="EffectiveConnectionType">
+  <caption><dfn>Table of effective connection types</dfn></caption>
+  <thead>
+    <tr>
+      <th>ECT</th>
+      <th>Minimum RTT (ms)</th>
+      <th>Maximum downlink (Kbps)</th>
+      <th>Explanation</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><dfn>slow-2g</dfn></td>
+      <td>1900</td>
+      <td>50</td>
+      <td>The network is suited for small transfers only such as text-only pages.</td>
+    </tr>
+    <tr>
+      <td><dfn>2g</dfn></td>
+      <td>1300</td>
+      <td>70</td>
+      <td>The network is suited for transfers of small images.</td>
+    </tr>
+    <tr>
+      <td><dfn>3g</dfn></td>
+      <td>200</td>
+      <td>700</td>
+      <td>The network is suited for transfers of large assets such as high resolution images, audio, and SD video.</td>
+    </tr>
+    <tr>
+      <td><dfn>4g</dfn></td>
+      <td>0</td>
+      <td>∞</td>
+      <td>The network is suited for HD video, real-time video, etc.</td>
+    </tr>
+  </tbody>
+</table>
+
+The above round-trip and bandwidth values are based on real user measurement observations:
+
+  * `slow-2g` is the 66.6th percentile of 2G observations
+  * `2g` is the 50th percentile of 2G observations
+  * `3g` is the 50th percentile of 3G observations
+
+The absolute values provided above are based on real user measurement on Chrome on Android, as captured in April 2017. The user agent MAY update these values in the future to reflect changes in the measurement data.
+
+The <a>effective connection types</a> are represented in this API by the <a>EffectiveConnectionType</a> enum.
+
+### <dfn>EffectiveConnectionType</dfn> enum
+
+<pre class="idl">
+  enum EffectiveConnectionType {
+    "2g",
+    "3g",
+    "4g",
+    "slow-2g"
+  };
 </pre>
 
 
-### `type` attribute
-The <dfn>`type`</dfn> attribute, when getting, returns the <a>connection type</a> that the user agent is using.
+## <dfn>NavigatorNetworkInformation</dfn> interface
 
-### `effectiveType` attribute
-The <dfn>`effectiveType`</dfn> attribute, when getting, returns the <a>effective connection type</a> that is determined using a combination of recently observed round trip times and downlink bandwidth.
+The `NavigatorNetworkInformation` interface exposes access to <a>`NetworkInformation`</a> interface by extending the <code><dfn data-cite="!HTML#navigator">Navigator</dfn></code> and <code><dfn data-cite="!HTML#workernavigator">WorkerNavigator</dfn></code> interface.
 
-### `downlinkMax` attribute
-The <dfn>`downlinkMax`</dfn> attribute represents an <dfn>upper bound on the downlink speed of the first network hop</dfn>. The reported value is in <a>megabits per second</a> and determined by the properties of the <a>underlying connection technology</a>.
+<pre class="idl">
+  [NoInterfaceObject, Exposed=(Window,Worker)]
+  interface NavigatorNetworkInformation {
+    readonly attribute NetworkInformation connection;
+  };
 
-<div class="note">
-The user agent has no knowledge of the total number or the performance characteristics of the various network hops required to fulfill a particular request; different requests may follow different routes and have different performance characteristics. The reported <a>upper bound on the downlink speed of the first network hop</a> value is determined by the properties of the <a>underlying connection technology</a> of the first network hop. The end-to-end performance of any request cannot exceed this value, but it is also not a guarantee of performance and may be significantly worse.
-</div>
+  Navigator implements NavigatorNetworkInformation;
+  WorkerNavigator implements NavigatorNetworkInformation;
+</pre>
 
-### `onchange` attribute
-The <dfn>`onchange`</dfn> event handler attribute handles "change" events fired during the <a>steps to update the connection values</a>.
+<section data-dfn-for="NavigatorNetworkInformation">
+  ### <dfn>connection</dfn> attribute
 
-### `downlink` attribute
-The <dfn>`downlink`</dfn> attribute represents the effective bandwidth estimate in <a>megabits per second</a> based on recently observed throughput on the client, rounded to nearest 25 kilobits per second.
+  The `connection` attribute, when getting, returns an object that implements the <a>NetworkInformation</a> interface.
+</section>
 
-### `rtt` attribute
-The <dfn>`rtt`</dfn> attribute represents the effective round-trip time estimate in <dfn data-lt="Millisecond">milliseconds</dfn> based on recently observed round-trip times on the client, rounded to nearest 25 milliseconds.
+<section data-dfn-for="NetworkInformation">
+  ## <dfn>NetworkInformation</dfn> interface
+
+  The `NetworkInformation` interface provides a means to access information about the network connection the user agent is currently using. The <code><dfn data-cite="DOM#interface-eventtarget">EventTarget</dfn></code> is defined in [[!DOM]]. 
+
+  <pre class="idl">
+  [Exposed=(Window,Worker)]
+  interface NetworkInformation : EventTarget {
+    readonly attribute ConnectionType type;
+    readonly attribute EffectiveConnectionType effectiveType;
+    readonly attribute Megabit downlinkMax;
+    readonly attribute Megabit downlink;
+    readonly attribute Millisecond rtt;
+    attribute EventHandler onchange;
+  };
+
+  typedef unrestricted double Megabit;
+  typedef unsigned long long Millisecond;
+  </pre>
+
+  ### <dfn>type</dfn> attribute
+  
+  The `type` attribute, when getting, returns the <a>connection type</a> that the user agent is using.
+
+  ### <dfn>effectiveType</dfn> attribute
+  
+  The `effectiveType` attribute, when getting, returns the <a>effective connection type</a> that is determined using a combination of recently observed round trip times and downlink bandwidth.
+
+  ### <dfn>downlinkMax</dfn> attribute
+  
+  The `downlinkMax` attribute represents an <dfn>upper bound on the downlink speed of the first network hop</dfn>. The reported value is in <a>megabits per second</a> and determined by the properties of the <a>underlying connection technology</a>.
+
+  <div class="note">
+    The user agent has no knowledge of the total number or the performance characteristics of the various network hops required to fulfill a particular request; different requests may follow different routes and have different performance characteristics. The reported <a>upper bound on the downlink speed of the first network hop</a> value is determined by the properties of the <a>underlying connection technology</a> of the first network hop. The end-to-end performance of any request cannot exceed this value, but it is also not a guarantee of performance and may be significantly worse.
+  </div>
+
+  ### <dfn>onchange</dfn> attribute
+  
+  The `onchange` event handler attribute handles "change" events fired during the <a>steps to update the connection values</a>.
+
+  ### <dfn>downlink</dfn> attribute
+  
+  The `downlink` attribute represents the effective bandwidth estimate in <a>megabits per second</a> based on recently observed throughput on the client, rounded to nearest 25 kilobits per second.
+
+  ### <dfn>rtt</dfn> attribute
+  
+  The `rtt` attribute represents the effective round-trip time estimate in <dfn data-lt="Millisecond">milliseconds</dfn> based on recently observed round-trip times on the client, rounded to nearest 25 milliseconds.
+  
+</section>
 
 
 ## Underlying connection technology
@@ -315,7 +347,7 @@ The <dfn>downlinkMax for an available interface</dfn> is determined via the stan
 The <a>upper bound on the downlink speed of the first network hop</a> is determined by the rules described in <a href="#handling-changes-to-the-underlying-connection">handling changes to the underlying connection</a>.
 
 <div class="note">
-The enumeration of available network interfaces and their generation and version is not directly exposed to script. Instead, `downlinkMax` exposes a single value in <a>megabits per second</a> that accounts for all available interfaces and their current network conditions.
+  The enumeration of available network interfaces and their generation and version is not directly exposed to script. Instead, `downlinkMax` exposes a single value in <a>megabits per second</a> that accounts for all available interfaces and their current network conditions.
 </div>
 
 <table id="max-downlink-table" class="simple" data-link-for="ConnectionType">
@@ -336,94 +368,55 @@ The enumeration of available network interfaces and their generation and version
   </tbody>
 </table>
 
+<section data-link-for="NetworkInformation">
 ### Handling changes to the underlying connection
 
 When the properties of the <a>underlying connection technology</a> change, due to a switch to a different <a>connection type</a> or <a>effective connection type</a>, change in <a>upper bound on the downlink speed of the first network hop</a>, or change in effective <a>downlink</a> or <a>rtt</a> estimates, the user agent MUST run the <dfn>steps to update the connection values</dfn>:
 
-1. Let <var>new-type</var> be the <a>connection type</a> that represents the <a>underlying connection technology</a>.
-1. Let <var>new-effective-type</var> be the <a>effective connection type</a> determined by current <a>downlink</a> and <a>rtt</a> values.
-1. Let <var>new-downlink</var> be the <a>downlink</a> value.
-1. Let <var>new-rtt</var> be the <a>rtt</a> value.
-1. If <var>new-type</var> is "none", set <var>max-value</var> to `0`.
-1. if <var>new-type</var> is "unknown", set <var>max-value</var> to `+Infinity`.
-1. If <var>new-type</var> is "mixed", set <var>max-value</var> to an applicable value for the interface configuration used to service new network requests - e.g. if multiple interfaces may be used, sum their <a>downlinkMax for an available interface</a> values.
-1. Otherwise, set <var>max-value</var> to <a>downlinkMax for an available interface</a>.
-1. If <var>max-value</var> is not equal to the value of `connection.downlinkMax`, or if <var>new-type</var> is not equal to the value of `connection.type`, or if <var>new-downlink</var> is not equal to the value of `connection.downlink`, or if <var>new-rtt</var> is not equal to the value of `connection.rtt`:
+  1. Let <var>new-type</var> be the <a>connection type</a> that represents the <a>underlying connection technology</a>.
+  1. Let <var>new-effective-type</var> be the <a>effective connection type</a> determined by current <a>downlink</a> and <a>rtt</a> values.
+  1. Let <var>new-downlink</var> be the <a>downlink</a> value.
+  1. Let <var>new-rtt</var> be the <a>rtt</a> value.
+  1. If <var>new-type</var> is "none", set <var>max-value</var> to `0`.
+  1. if <var>new-type</var> is "unknown", set <var>max-value</var> to `+Infinity`.
+  1. If <var>new-type</var> is "mixed", set <var>max-value</var> to an applicable value for the interface configuration used to service new network requests - e.g. if multiple interfaces may be used, sum their <a>downlinkMax for an available interface</a> values.
+  1. Otherwise, set <var>max-value</var> to <a>downlinkMax for an available interface</a>.
+  1. If <var>max-value</var> is not equal to the value of `connection.downlinkMax`, or if <var>new-type</var> is not equal to the value of `connection.type`, or if <var>new-downlink</var> is not equal to the value of `connection.downlink`, or if <var>new-rtt</var> is not equal to the value of `connection.rtt`:
     1. Using the <a data-cite="!HTML#networking-task-source">networking task source</a>, <a data-cite="!HTML#queue-a-task">queue a task</a> to perform the following:
-        1. Set `connection.downlinkMax` to <var>max-value</var>.
-        1. Set `connection.type` to <var>new-type</var>.
-        1. set `connection.effectiveType` to <var>new-effective-type</var>.
-        1. Set `connection.downlink` to <var>new-downlink</var>.
-        1. Set `connection.rtt` to <var>new-rtt</var>.
-        1. <a data-cite="!DOM#concept-event-fire">Fire an event</a> named `change` at the `NetworkInformation` object.
+      1. Set `connection.downlinkMax` to <var>max-value</var>.
+      1. Set `connection.type` to <var>new-type</var>.
+      1. set `connection.effectiveType` to <var>new-effective-type</var>.
+      1. Set `connection.downlink` to <var>new-downlink</var>.
+      1. Set `connection.rtt` to <var>new-rtt</var>.
+      1. <a data-cite="!DOM#concept-event-fire">Fire an event</a> named `change` at the `NetworkInformation` object.
 </section>
 
-<section>
-  ## The <dfn>ConnectionType</dfn> enum
+## Privacy Considerations
 
-  <pre class="idl">
-  enum ConnectionType {
-    "bluetooth",
-    "cellular",
-    "ethernet",
-    "mixed",
-    "none",
-    "other",
-    "unknown",
-    "wifi",
-    "wimax"
-  };
-  </pre>
-</section>
+The Network Information API exposes information about the observed network bandwidth, latency and the first network hop between the user agent and the server; specifically, the type of connection and the upper bound of the downlink speed, as well as signals whenever this information changes. Such information may be used to:
 
-<section>
-  ## The <dfn>EffectiveConnectionType</dfn> enum
+  * Fingerprint a user based on characteristics of a particular network (e.g. type and downlink estimates) at a point in time, and by observing change in such characteristics over a period of time.
+  * Fingerprint a user based on transitions between one or more networks (e.g. based on order of transitions by type, downlink estimates, and time).
+  * Infer user location (e.g. are they home, at work, or in transit) based on above criteria.
 
-  <pre class="idl">
-  enum EffectiveConnectionType {
-    "slow-2g",
-    "2g",
-    "3g",
-    "4g"
-  };
-  </pre>
-</section>
+However, above considerations are not new, and sufficiently motivated attackers may already obtain such information using other technologies:
 
+  * The attacker can use JavaScript to observe the duration (e.g. time from start of fetch to `onload` event) of any network fetch on the client, and may get more detailed timing data about the same fetch via the Resource Timing API.
+  * The attacker can use WebRTC to identify client's public and private IP addresses via STUN, or similar mechanisms.
+  * The attacker can observe the client IP, fetch duration, RTT, transfer speed, and other low-level socket metrics of a fetch on the server.
 
-<section id="privacy">
-  ## Privacy Considerations
+Further, by repeating one of the above strategies (e.g. via invoking periodic fetch or refresh of a resource; via periodic SSE or WebSocket messages; via periodic STUN requests, etc.), the attacker can observe changes over time in the performance characteristics of client's connection and IP address. Such data can then be used to refine the user fingerprint, infer users location (e.g. are they home, at work, or in transit), and extract various behavioral patterns.
 
-  The Network Information API exposes information about the observed network bandwidth, latency and the first network hop between the user agent and the server; specifically, the type of connection and the upper bound of the downlink speed, as well as signals whenever this information changes. Such information may be used to:
+The above list is not a complete overview. However, as the above examples illustrate, the attacks are possible both from the sender and the receiver:
 
-  <ul>
-    <li>Fingerprint a user based on characteristics of a particular network (e.g. type and downlink estimates) at a point in time, and by observing change in such characteristics over a period of time.</li>
-    <li>Fingerprint a user based on transitions between one or more networks (e.g. based on order of transitions by type, downlink estimates, and time).</li>
-    <li>Infer user location (e.g. are they home, at work, or in transit) based on above criteria.</li>
-  </ul>
+  * If the attacker can initiate or observe a network fetch of any kind from the client, then they can observe its performance characteristics and how they change over time.
+  * If the attacker can convince the client to fetch a resource from their server, then they can similarly observe the performance characteristics of the fetch and how they change over time.
 
-  However, above considerations are not new, and sufficiently motivated attackers may already obtain such information using other technologies:
+Mitigating such attacks initiated from the client requires preventing the attacker from observing and initiating network requests - e.g., use HTTPS to prevent trivial content injection by malicious parties; disable JavaScript to prevent scripted resource fetch of any kind. Mitigating attacks from the sender is possible via the use of a VPN or an HTTP proxy - e.g. to hide the client's true IP address, to introduce additional latency, and so on.
 
-  <ul>
-    <li>The attacker can use JavaScript to observe the duration (e.g. time from start of fetch to `onload` event) of any network fetch on the client, and may get more detailed timing data about the same fetch via the Resource Timing API.</li>
-    <li>The attacker can use WebRTC to identify client's public and private IP addresses via STUN, or similar mechanisms.</li>
-    <li>The attacker can observe the client IP, fetch duration, RTT, transfer speed, and other low-level socket metrics of a fetch on the server.</li>
-  </ul>
+As such, while the Network Information API makes it easier to obtain information about the first network hop, by avoiding the need to observe or make network requests, it does not expose anything that is not already available to a sufficiently-motivated attacker.
 
-  Further, by repeating one of the above strategies (e.g. via invoking periodic fetch or refresh of a resource; via periodic SSE or WebSocket messages; via periodic STUN requests, etc.), the attacker can observe changes over time in the performance characteristics of client's connection and IP address. Such data can then be used to refine the user fingerprint, infer users location (e.g. are they home, at work, or in transit), and extract various behavioral patterns.
-
-  The above list is not a complete overview. However, as the above examples illustrate, the attacks are possible both from the sender and the receiver:
-
-  <ul>
-    <li>If the attacker can initiate or observe a network fetch of any kind from the client, then they can observe its performance characteristics and how they change over time.</li>
-    <li>If the attacker can convince the client to fetch a resource from their server, then they can similarly observe the performance characteristics of the fetch and how they change over time.</li>
-  </ul>
-
-  Mitigating such attacks initiated from the client requires preventing the attacker from observing and initiating network requests - e.g., use HTTPS to prevent trivial content injection by malicious parties; disable JavaScript to prevent scripted resource fetch of any kind. Mitigating attacks from the sender is possible via the use of a VPN or an HTTP proxy - e.g. to hide the client's true IP address, to introduce additional latency, and so on.
-
-  As such, while the Network Information API makes it easier to obtain information about the first network hop, by avoiding the need to observe or make network requests, it does not expose anything that is not already available to a sufficiently-motivated attacker.
-
-  If the client wants to mitigate this class of attacks, they should disable JavaScript, monitor that all outbound requests are made to trusted origins, and make diligent use of anonymizing VPN/proxy services.
-</section>
+If the client wants to mitigate this class of attacks, they should disable JavaScript, monitor that all outbound requests are made to trusted origins, and make diligent use of anonymizing VPN/proxy services.
 
 <section id="conformance">
   There is only one class of product that can claim conformance to this

--- a/index.html
+++ b/index.html
@@ -59,6 +59,11 @@ var respecConfig = {
   edDraftURI: "https://wicg.github.io/netinfo/",
   editors: [
     {
+      name: "Ilya Grigorik",
+      company: "Google",
+      companyURL: "http://google.com",
+    },
+    {
       name: "Marcos Cáceres",
       company: "Mozilla Corporation",
       companyURL: "http://mozilla.com",
@@ -67,11 +72,6 @@ var respecConfig = {
       name: "Fernando Jiménez Moreno",
       company: "Telefonica",
       companyURL: "http://www.telefonica.com/en/home/jsp/home.jsp",
-    },
-    {
-      name: "Ilya Grigorik",
-      company: "Google",
-      companyURL: "http://google.com",
     },
   ],
   wg: "Web Incubator Community Group",


### PR DESCRIPTION
As part of fixing markdown processing bugs in ReSpec, I cleaned up the markdown of the spec. I also fixed a couple of broken links, etc.

@igrigorik, moved a couple of sections around, to better align with how the spec defines things (e.g., connection types is now followed by the ConnectionType enum).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/WICG/netinfo/cleanup.html) | [Diff](https://s3.amazonaws.com/pr-preview/WICG/netinfo/0653980...755e01e.html)