### PR TITLE
clarify how rtt & downlink are determined

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@ The `NavigatorNetworkInformation` interface exposes access to <a>`NetworkInforma
 
   ### <dfn>effectiveType</dfn> attribute
 
-  The `effectiveType` attribute, when getting, returns the <a>effective connection type</a> that is determined using a combination of recently observed round trip times and downlink bandwidth.
+  The `effectiveType` attribute, when getting, returns the <a>effective connection type</a> that is determined using a combination of recently observed <a href="#dom-networkinformation-rtt">rtt</a> and <a href="#dom-networkinformation-downlink">downlink</a> values.
 
   ### <dfn>downlinkMax</dfn> attribute
 
@@ -310,11 +310,11 @@ The `NavigatorNetworkInformation` interface exposes access to <a>`NetworkInforma
 
   ### <dfn>downlink</dfn> attribute
 
-  The `downlink` attribute represents the effective bandwidth estimate in <a>megabits per second</a> based on recently observed throughput on the client, rounded to nearest multiple of 25 kilobits per second.
+  The `downlink` attribute represents the effective bandwidth estimate in <a>megabits per second</a>, rounded to nearest multiple of 25 kilobits per second, and is based on recently observed transport-layer throughput across recently active connections. In absence of recent bandwidth measurement data, the attribute value is determined by the properties of the <a>underlying connection technology</a>.
 
   ### <dfn>rtt</dfn> attribute
 
-  The `rtt` attribute represents the effective round-trip time estimate in <dfn data-lt="Millisecond">milliseconds</dfn> based on recently observed round-trip times on the client, rounded to nearest multiple of 25 milliseconds.
+  The `rtt` attribute represents the effective round-trip time estimate in <dfn data-lt="Millisecond">milliseconds</dfn>, rounded to nearest multiple of 25 milliseconds, and is based on recently observed transport-layer RTT measurements across recently active connections. In absence of recent RTT measurement data, the attribute value is determined by the properties of the <a>underlying connection technology</a>.
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@ The `NavigatorNetworkInformation` interface exposes access to <a>`NetworkInforma
   The `connection` attribute, when getting, returns an object that implements the <a>NetworkInformation</a> interface.
 </section>
 
-<section data-dfn-for="NetworkInformation">
+<section data-dfn-for="NetworkInformation" data-link-for="NetworkInformation">
   ## <dfn>NetworkInformation</dfn> interface
 
   The `NetworkInformation` interface provides a means to access information about the network connection the user agent is currently using. The <code><dfn data-cite="DOM#interface-eventtarget">EventTarget</dfn></code> is defined in [[!DOM]].
@@ -294,7 +294,7 @@ The `NavigatorNetworkInformation` interface exposes access to <a>`NetworkInforma
 
   ### <dfn>effectiveType</dfn> attribute
 
-  The `effectiveType` attribute, when getting, returns the <a>effective connection type</a> that is determined using a combination of recently observed <a href="#dom-networkinformation-rtt">rtt</a> and <a href="#dom-networkinformation-downlink">downlink</a> values.
+  The `effectiveType` attribute, when getting, returns the <a>effective connection type</a> that is determined using a combination of recently observed <a>rtt</a> and <a>downlink</a> values.
 
   ### <dfn>downlinkMax</dfn> attribute
 


### PR DESCRIPTION
Closes #56, #55.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/WICG/netinfo/clarify-rtt-downlink.html) | [Diff](https://s3.amazonaws.com/pr-preview/WICG/netinfo/01edb11...888c220.html)