### PR TITLE
Revamp of the "Requirements and use cases" section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ It should be queryable in an ad hoc fashion from client pages, and should also b
 **Example use cases:**
 
 *   A web application whose primary purpose is to stream media could check `navigator.connection.type` prior to playback. When it's set to `'cellular'`, it could advise users that their mobile network operator might be charging for the bandwidth, and only start automatic playback of previously cached content.
-*   A web application that makes use of a service worker to [cache](https://w3c.github.io/ServiceWorker/v1/#cache-objects) resources during [installation](https://w3c.github.io/ServiceWorker/v1/#installation-algorithm) might have different bundles of assets that it might cache: a list of crucial assets that are cached unconditionally, and a bundle of larger, optional assets that are only cached ahead of time when `navigator.connection.type` is '`ethernet'` or '`wifi'`.
+*   A web application that makes use of a service worker to [cache](https://w3c.github.io/ServiceWorker/v1/#cache-objects) resources during [installation](https://w3c.github.io/ServiceWorker/v1/#installation-algorithm) might have different bundles of assets that it might cache: a list of crucial assets that are cached unconditionally, and a bundle of larger, optional assets that are only cached ahead of time when `navigator.connection.type` is `'ethernet'` or `'wifi'`.
 *   A web application that uses a service worker with a [background sync](https://github.com/WICG/BackgroundSync/blob/master/explainer.md) handler might check the current `navigator.connection.type` value, and only transfer data inside the `sync` event handler if it is is `'ethernet'` or `'wifi'`.
 
 ### Provide a way for scripts to be notified if the connection type changes.
@@ -118,7 +118,7 @@ This allows developers to make dynamic changes to their user interface to inform
 **Example use cases:**
 
 *   A web application whose primary purpose is to stream media could dynamically change its user interface in response to updates to the connection type. This may afford a better user experience than waiting until a user attempts to playback and performing a one-off query. It allows applications to provide context about the connection in advance of user interaction.
-*   A web application that allows for uploads or downloads might defer initiating the request when `navigator.connection.type` is set to ``'cellular'`, and add a listener for changes to the connection. When a change to a high-bandwidth network type is detected, the request could be automatically started.
+*   A web application that allows for uploads or downloads might defer initiating the request when `navigator.connection.type` is set to `'cellular'`, and add a listener for changes to the connection. When a change to a high-bandwidth network type is detected, the request could be automatically started.
 
 <section class="informative">
   ## Examples of usage

--- a/index.html
+++ b/index.html
@@ -97,12 +97,28 @@ var respecConfig = {
 
 <section id='sotd'></section>
 
-## Use cases and requirements
+## Requirements and use cases
 
-This document attempts to address the <a data-cite="netinfo-usecases#requirements">requirements</a> from the <a data-cite="netinfo-usecases">Review of Apps that Use Network Information</a>. Those are:
+This document describes an API that addresses two specific requirements:
 
- * Provide access to the <a>connection type</a> the system is using to communicate with the network (e.g., cellular, bluetooth, ethernet, wifi, other, or none). This information needs to be available either immediately on page load or as close as possible to it.
- * Provide a means for scripts to be notified if the <a>connection type</a> changes. This is to allow developers to make dynamic changes to the DOM and/or inform the user that the network <a>connection type</a> has changed (and that it could impact them in some way).
+### Provide an interface for determining the [connection type](https://wicg.github.io/netinfo/#dfn-connection-types) currently used to communicate with the network.
+
+It should be queryable in an ad hoc fashion from client pages, and should also be available in other contexts, like exposed to [service workers](https://w3c.github.io/ServiceWorker/v1/).
+
+**Example use cases:**
+
+*   A web application whose primary purpose is to stream media could check `navigator.connection.type` prior to playback. When it's set to `'cellular'`, it could advise users that their mobile network operator might be charging for the bandwidth, and only start automatic playback of previously cached content.
+*   A web application that makes use of a service worker to [cache](https://w3c.github.io/ServiceWorker/v1/#cache-objects) resources during [installation](https://w3c.github.io/ServiceWorker/v1/#installation-algorithm) might have different bundles of assets that it might cache: a list of crucial assets that are cached unconditionally, and a bundle of larger, optional assets that are only cached ahead of time when `navigator.connection.type` is '`ethernet'` or '`wifi'`.
+*   A web application that uses a service worker with a [background sync](https://github.com/WICG/BackgroundSync/blob/master/explainer.md) handler might check the current `navigator.connection.type` value, and only transfer data inside the `sync` event handler if it is is `'ethernet'` or `'wifi'`.
+
+### Provide a way for scripts to be notified if the connection type changes.
+
+This allows developers to make dynamic changes to their user interface to inform the user that the network connection type has changed, and that it could impact them in some way. It also allows applications that were deferring the transfer of large amounts of data to automatically begin once a high-bandwidth network is detected.
+
+**Example use cases:**
+
+*   A web application whose primary purpose is to stream media could dynamically change its user interface in response to updates to the connection type. This may afford a better user experience than waiting until a user attempts to playback and performing a one-off query. It allows applications to provide context about the connection in advance of user interaction.
+*   A web application that allows for uploads or downloads might defer initiating the request when `navigator.connection.type` is set to ``'cellular'`, and add a listener for changes to the connection. When a change to a high-bandwidth network type is detected, the request could be automatically started.
 
 <section class="informative">
   ## Examples of usage


### PR DESCRIPTION
R: @igrigorik 

As per out-of-band discussion, here's a revamp of the "Requirements and use cases section", with information distilled from https://www.w3.org/TR/netinfo-usecases/#requirements and augmented with some additional, service worker-y use cases.

It looks like:

<img width="748" alt="screen shot 2017-08-22 at 12 41 04 pm" src="https://user-images.githubusercontent.com/1749548/29576796-2f886720-8737-11e7-9a96-d385009fa6f6.png">