### PR TITLE
some cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@ The `NavigatorNetworkInformation` interface exposes access to <a>`NetworkInforma
 
   #### `ECT` Request Header Field
 
-  The `ECT` [[!CLIENT-HINTS]] request header field is a token that indicates the <a>effectiveType</a>, which is one of <a>EffectiveConnectionType</a> values, at the time when the request is made by the user agent.
+  The `ECT` request header field is a token that indicates the <a>effectiveType</a>, which is one of <a>EffectiveConnectionType</a> values, at the time when the request is made by the user agent.
 
   <pre class="nohighlight">
     ECT = sd-token \*( OWS ";" OWS [sd-token] )
@@ -354,7 +354,7 @@ The `NavigatorNetworkInformation` interface exposes access to <a>`NetworkInforma
 
   #### `Downlink` Request Header Field
 
-  The `Downlink` [[!CLIENT-HINTS]] request header field is a number that indicates the <a>downlink</a> value at the time when the request is made by the user agent.
+  The `Downlink` request header field is a number that indicates the <a>downlink</a> value at the time when the request is made by the user agent.
 
   <pre class="nohighlight">
     Downlink = 1\*DIGIT [ "." 1\*DIGIT ]
@@ -370,7 +370,7 @@ The `NavigatorNetworkInformation` interface exposes access to <a>`NetworkInforma
 
   #### `RTT` Request Header Field
 
-  The `RTT` [[!CLIENT-HINTS]] request header field is a number that indicates the <a>rtt</a> value at the time when the request is made by the user agent.
+  The `RTT` request header field is a number that indicates the <a>rtt</a> value at the time when the request is made by the user agent.
 
   <pre class="nohighlight">
     RTT = 1\*DIGIT


### PR DESCRIPTION
as part of addressing #71 it seems that in the current version of this spec, only `Save-Data` remains as the header field defined in the `draft-ietf-httpbis-client-hints` spec. the other ones are defined here in the `netinfo-api` spec, right?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dret/netinfo/pull/72.html" title="Last updated on Jun 8, 2018, 3:51 PM GMT (cefbe94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/netinfo/72/431112d...dret:cefbe94.html" title="Last updated on Jun 8, 2018, 3:51 PM GMT (cefbe94)">Diff</a>