### PR TITLE
Remove Save-Data and reference Client Hints

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,19 @@ var respecConfig = {
       href: "https://tools.ietf.org/html/draft-grigorik-http-client-hints",
       status: "Internet-Draft",
       publisher: "IETF",
-    }
+    },
+    "CLIENT-HINTS-INFRASTRUCTURE": {
+      title: "Client Hints Infrastructure",
+      href: "https://wicg.github.io/client-hints-infrastructure/",
+      status: "CG Draft",
+      publisher: "WICG",
+    },
+    "STRUCTURED-HEADERS": {
+      title: "Structured Headers for HTTP",
+      href: "https://tools.ietf.org/html/draft-ietf-httpbis-header-structure",
+      status: "Internet-Draft",
+      publisher: "IETF",
+    },
   },
 };
 </script>
@@ -298,13 +310,14 @@ The <code><dfn data-cite="!HTML#navigator">Navigator</dfn></code> and <code><dfn
     readonly attribute Megabit downlinkMax;
     readonly attribute Megabit downlink;
     readonly attribute Millisecond rtt;
-    readonly attribute boolean saveData;
     attribute EventHandler onchange;
   };
 
   typedef unrestricted double Megabit;
   typedef unsigned long long Millisecond;
   </pre>
+
+  This section also defines a number of HTTP request header fields that expose details about the user's network conditions, which servers can opt-into receiving. They can do that via the Client Hints infrastructure defined in [[CLIENT-HINTS]] and bound by the processing model defined in [[CLIENT-HINTS-INFRASTRUCTURE]].
 
   ### <dfn>type</dfn> attribute
 
@@ -317,15 +330,7 @@ The <code><dfn data-cite="!HTML#navigator">Navigator</dfn></code> and <code><dfn
   #### <code><dfn>ECT</dfn></code> Request Header Field
 
   The <a>ECT</a> request header field is a token that indicates the <a>effectiveType</a>, which is one of <a>EffectiveConnectionType</a> values, at the time when the request is made by the user agent.
-
-  <pre class="nohighlight">
-    ECT = sd-token \*( OWS ";" OWS [sd-token] )
-    sd-token = token
-  </pre>
-
-  If `ECT` occurs in a message more than once, the last value overrides
-  all previous occurrences.
-
+  It is a Structured Header whose value must be a Token. [[STRUCTURED-HEADERS]]
 
   ### <dfn>downlinkMax</dfn> attribute
 
@@ -346,14 +351,7 @@ The <code><dfn data-cite="!HTML#navigator">Navigator</dfn></code> and <code><dfn
   #### `Downlink` Request Header Field
 
   The <a>Downlink</a> request header field is a number that indicates the <a>downlink</a> value at the time when the request is made by the user agent.
-
-  <pre class="nohighlight">
-    Downlink = 1\*DIGIT [ "." 1\*DIGIT ]
-  </pre>
-
-  If `Downlink` occurs in a message more than once, the last value overrides
-  all previous occurrences.
-
+  It is a Structured Header whose value must be a Decimal. [[STRUCTURED-HEADERS]]
 
   ### <dfn>rtt</dfn> attribute
 
@@ -362,38 +360,7 @@ The <code><dfn data-cite="!HTML#navigator">Navigator</dfn></code> and <code><dfn
   #### `RTT` Request Header Field
 
   The <a>RTT</a> request header field is a number that indicates the <a>rtt</a> value at the time when the request is made by the user agent.
-
-  <pre class="nohighlight">
-    RTT = 1\*DIGIT
-  </pre>
-
-  If `RTT` occurs in a message more than once, the last value overrides all previous occurrences.
-
-
-  ### <dfn>saveData</dfn> attribute
-
-  The <a>saveData</a> attribute, when getting, returns `true` if the user has requested a reduced data usage mode from the user agent, and `false` otherwise.
-
-  <p class="note">The user may enable such preference, if made available by the user agent, due to high data transfer costs, slow connection speeds, or other reasons.</p>
-
-  #### <code><dfn>Save-Data</dfn></code> Request Header Field
-
-  The <a>SaveData</a> [[!CLIENT-HINTS]] request header field consists of one or more tokens that indicate user agent's preference for reduced data usage.
-
-  <pre class="nohighlight">
-    Save-Data = sd-token \*( OWS ";" OWS [sd-token] )
-    sd-token = token
-  </pre>
-
-  This specification defines the "`on`" `sd-token` value, which is used as a signal indicating explicit user opt-in into a reduced data usage mode (i.e. when <a>saveData</a>'s value is `true`), and when communicated to origins allows them to deliver alternate content honoring such preference - e.g. smaller image and video resources, alternate markup, and so on.
-
-  If <a>Save-Data</a> occurs in a message more than once, the last value overrides all previous occurrences.
-
-  <div class="issue">
-    TODO: update <a href="https://fetch.spec.whatwg.org/#fetching">Fetch#fetching algorithm</a> to use `connection.saveData` as signal to append the Save-Data header.
-  </div>
-</section>
-
+  It is a Structured Header whose value must be an Integer. [[STRUCTURED-HEADERS]]
 
 ## Underlying connection technology
 
@@ -428,11 +395,10 @@ The <a>upper bound on the downlink speed of the first network hop</a> is determi
 <section data-link-for="NetworkInformation">
 ### Handling changes to the underlying connection
 
-When the properties of the <a>underlying connection technology</a> change, due to a switch to a different <a>connection type</a> or <a>effective connection type</a>, change in <a>upper bound on the downlink speed of the first network hop</a>, change in effective <a>downlink</a> or <a>rtt</a> estimates, or change in <a>saveData</a> preference, the user agent MUST run the <dfn>steps to update the connection values</dfn>:
+When the properties of the <a>underlying connection technology</a> change, due to a switch to a different <a>connection type</a> or <a>effective connection type</a>, change in <a>upper bound on the downlink speed of the first network hop</a>, or change in effective <a>downlink</a> or <a>rtt</a> estimates, the user agent MUST run the <dfn>steps to update the connection values</dfn>:
 
   1. Let <var>new-type</var> be the <a>connection type</a> that represents the <a>underlying connection technology</a>.
   1. Let <var>new-effective-type</var> be the <a>effective connection type</a> determined by current <a>downlink</a> and <a>rtt</a> values.
-  1. Let <var>new-saveData</var> be the current <a>saveData</a> preference.
   1. Let <var>new-downlink</var> be the result of:
     1. Rounding <a>downlink</a> value to nearest multiple of 25 kilobits per second.
     1. If the resulting value is 10% greater or smaller than the value of `connection.downlink`, then set <var>new-dowlink</var> to resulting value. Otherwise, set <var>new-downlink</var> to the value of `connection.downlink`.
@@ -443,14 +409,13 @@ When the properties of the <a>underlying connection technology</a> change, due t
   1. if <var>new-type</var> is "unknown", set <var>max-value</var> to `+Infinity`.
   1. If <var>new-type</var> is "mixed", set <var>max-value</var> to an applicable value for the interface configuration used to service new network requests - e.g. if multiple interfaces may be used, sum their <a>downlinkMax for an available interface</a> values.
   1. Otherwise, set <var>max-value</var> to <a>downlinkMax for an available interface</a>.
-  1. If <var>max-value</var> is not equal to the value of `connection.downlinkMax`, or if <var>new-type</var> is not equal to the value of `connection.type`, or if <var>new-downlink</var> is not equal to the value of `connection.downlink`, or if <var>new-rtt</var> is not equal to the value of `connection.rtt`, or if <var>new-saveData</var> is not equal to the value of `connection.saveData`:
+  1. If <var>max-value</var> is not equal to the value of `connection.downlinkMax`, or if <var>new-type</var> is not equal to the value of `connection.type`, or if <var>new-downlink</var> is not equal to the value of `connection.downlink`, or if <var>new-rtt</var> is not equal to the value of `connection.rtt`:
     1. Using the <a data-cite="!HTML#networking-task-source">networking task source</a>, <a data-cite="!HTML#queue-a-task">queue a task</a> to perform the following:
       1. Set `connection.downlinkMax` to <var>max-value</var>.
       1. Set `connection.type` to <var>new-type</var>.
       1. set `connection.effectiveType` to <var>new-effective-type</var>.
       1. Set `connection.downlink` to <var>new-downlink</var>.
       1. Set `connection.rtt` to <var>new-rtt</var>.
-      1. Set `connection.saveData` to <var>new-saveData</var>.
       1. <a data-cite="!DOM#concept-event-fire">Fire an event</a> named `change` at the `NetworkInformation` object.
 </section>
 


### PR DESCRIPTION
Following comments on https://github.com/mozilla/standards-positions/issues/117 I noticed that the spec is out-of-date on a couple of aspects:
* Save-data has moved to [its own spec](https://wicg.github.io/savedata/), but wasn't removed from here.
* The request headers are not properly defined as Client Hints.

This PR fixes that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/netinfo-1/pull/83.html" title="Last updated on Apr 16, 2020, 7:49 AM UTC (5be36e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/netinfo/83/cc06920...yoavweiss:5be36e6.html" title="Last updated on Apr 16, 2020, 7:49 AM UTC (5be36e6)">Diff</a>